### PR TITLE
test(store): make stores created available

### DIFF
--- a/event-store/impl-fs/src/commonTest/kotlin/dev/eskt/store/impl/fs/FileSystemAppendStreamTest.kt
+++ b/event-store/impl-fs/src/commonTest/kotlin/dev/eskt/store/impl/fs/FileSystemAppendStreamTest.kt
@@ -6,7 +6,7 @@ import dev.eskt.store.test.StreamTestFactory
 import dev.eskt.store.test.w.car.CarStreamType
 
 internal class FileSystemAppendStreamTest : AppendStreamTest<FileSystemStorage, FileSystemEventStore>(
-    object : StreamTestFactory<FileSystemStorage, FileSystemEventStore> {
+    object : StreamTestFactory<FileSystemStorage, FileSystemEventStore>() {
         private val config = FileSystemConfig(
             basePath = createEmptyTemporaryFolder(),
             eventMetadataSerializer = DefaultEventMetadataSerializer,

--- a/event-store/impl-fs/src/commonTest/kotlin/dev/eskt/store/impl/fs/FileSystemLoadStreamTest.kt
+++ b/event-store/impl-fs/src/commonTest/kotlin/dev/eskt/store/impl/fs/FileSystemLoadStreamTest.kt
@@ -6,7 +6,7 @@ import dev.eskt.store.test.StreamTestFactory
 import dev.eskt.store.test.w.car.CarStreamType
 
 internal class FileSystemLoadStreamTest : LoadStreamTest<FileSystemStorage, FileSystemEventStore>(
-    object : StreamTestFactory<FileSystemStorage, FileSystemEventStore> {
+    object : StreamTestFactory<FileSystemStorage, FileSystemEventStore>() {
         private val config = FileSystemConfig(
             basePath = createEmptyTemporaryFolder(),
             eventMetadataSerializer = DefaultEventMetadataSerializer,

--- a/event-store/impl-memory/src/commonTest/kotlin/dev/eskt/store/impl/memory/InMemoryAppendStreamTest.kt
+++ b/event-store/impl-memory/src/commonTest/kotlin/dev/eskt/store/impl/memory/InMemoryAppendStreamTest.kt
@@ -5,7 +5,7 @@ import dev.eskt.store.test.StreamTestFactory
 import dev.eskt.store.test.w.car.CarStreamType
 
 internal class InMemoryAppendStreamTest : AppendStreamTest<InMemoryStorage, InMemoryEventStore>(
-    object : StreamTestFactory<InMemoryStorage, InMemoryEventStore> {
+    object : StreamTestFactory<InMemoryStorage, InMemoryEventStore>() {
         private val config = InMemoryConfig(
             registeredTypes = listOf(
                 CarStreamType,

--- a/event-store/impl-memory/src/commonTest/kotlin/dev/eskt/store/impl/memory/InMemoryLoadStreamTest.kt
+++ b/event-store/impl-memory/src/commonTest/kotlin/dev/eskt/store/impl/memory/InMemoryLoadStreamTest.kt
@@ -5,7 +5,7 @@ import dev.eskt.store.test.StreamTestFactory
 import dev.eskt.store.test.w.car.CarStreamType
 
 internal class InMemoryLoadStreamTest : LoadStreamTest<InMemoryStorage, InMemoryEventStore>(
-    object : StreamTestFactory<InMemoryStorage, InMemoryEventStore> {
+    object : StreamTestFactory<InMemoryStorage, InMemoryEventStore>() {
         private val config = InMemoryConfig(
             registeredTypes = listOf(
                 CarStreamType,

--- a/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/AppendStreamTest.kt
+++ b/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/AppendStreamTest.kt
@@ -13,17 +13,17 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @Suppress("DuplicatedCode")
-public abstract class AppendStreamTest<R : Storage, S : EventStore>(
-    private val factory: StreamTestFactory<R, S>,
+public open class AppendStreamTest<R : Storage, S : EventStore>(
+    protected val factory: StreamTestFactory<R, S>,
 ) {
     @Test
     @JsName("test1")
     public fun `given no events - when appending events on a stream - event is added`() {
         // given
-        val storage = factory.createStorage()
+        val storage = factory.newStorage()
 
         // when
-        val eventStore = factory.createEventStore(storage)
+        val eventStore = factory.newEventStore(storage)
         val event1 = CarProducedEvent(vin = "123", producer = 1, make = "kia", model = "rio")
         val metadata = mapOf(
             "m1" to "some text",
@@ -51,13 +51,13 @@ public abstract class AppendStreamTest<R : Storage, S : EventStore>(
     @JsName("test2")
     public fun `given 2 event from different streams - when appending events on a stream - event is added`() {
         // given
-        val storage = factory.createStorage()
+        val storage = factory.newStorage()
         storage.add(CarStreamType, "car-123", 1, CarProducedEvent(vin = "123", producer = 1, make = "kia", model = "rio"))
         storage.add(CarStreamType, "car-456", 1, CarProducedEvent(vin = "456", producer = 1, make = "kia", model = "rio"))
 
         // when
         val event1 = CarSoldEvent(seller = 1, buyer = 2, 2500.00f)
-        val eventStore = factory.createEventStore(storage)
+        val eventStore = factory.newEventStore(storage)
         eventStore
             .withStreamType(CarStreamType)
             .appendStream(
@@ -79,13 +79,13 @@ public abstract class AppendStreamTest<R : Storage, S : EventStore>(
     @JsName("test3")
     public fun `given 1 event from same stream - when appending event with already existing version - append is rejected`() {
         // given
-        val storage = factory.createStorage()
+        val storage = factory.newStorage()
         storage.add(CarStreamType, "car-123", 1, CarProducedEvent(vin = "123", producer = 1, make = "kia", model = "rio"))
         storage.add(CarStreamType, "car-123", 2, CarSoldEvent(seller = 1, buyer = 2, 2500.00f))
 
         // when
         val event1 = CarSoldEvent(seller = 1, buyer = 3, 2500.00f)
-        val eventStore = factory.createEventStore(storage)
+        val eventStore = factory.newEventStore(storage)
         val result = eventStore
             .withStreamType(CarStreamType)
             .appendStream(
@@ -105,12 +105,12 @@ public abstract class AppendStreamTest<R : Storage, S : EventStore>(
     @JsName("test4")
     public fun `given 1 event from same stream - when appending event out of order - append is rejected`() {
         // given
-        val storage = factory.createStorage()
+        val storage = factory.newStorage()
         storage.add(CarStreamType, "car-123", 1, CarProducedEvent(vin = "123", producer = 1, make = "kia", model = "rio"))
 
         // when
         val event1 = CarSoldEvent(seller = 1, buyer = 2, 2500.00f)
-        val eventStore = factory.createEventStore(storage)
+        val eventStore = factory.newEventStore(storage)
         val result = eventStore
             .withStreamType(CarStreamType)
             .appendStream(

--- a/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/LoadStreamTest.kt
+++ b/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/LoadStreamTest.kt
@@ -12,16 +12,16 @@ import kotlin.test.assertEquals
 
 @Suppress("DuplicatedCode")
 public open class LoadStreamTest<R : Storage, S : EventStore>(
-    private val factory: StreamTestFactory<R, S>,
+    protected val factory: StreamTestFactory<R, S>,
 ) {
     @Test
     @JsName("test1")
     public fun `given no events - when loading events of a stream - list is empty`() {
         // given
-        val storage = factory.createStorage()
+        val storage = factory.newStorage()
 
         // when
-        val eventStore = factory.createEventStore(storage)
+        val eventStore = factory.newEventStore(storage)
         val eventEnvelopes = eventStore
             .withStreamType(CarStreamType)
             .loadStream(
@@ -37,13 +37,13 @@ public open class LoadStreamTest<R : Storage, S : EventStore>(
     @JsName("test2")
     public fun `given 3 event from different streams - when loading one stream - correct events are loaded`() {
         // given
-        val storage = factory.createStorage()
+        val storage = factory.newStorage()
         storage.add(CarStreamType, "car-123", 1, CarProducedEvent(vin = "123", producer = 1, make = "kia", model = "rio"))
         storage.add(CarStreamType, "car-456", 1, CarProducedEvent(vin = "456", producer = 1, make = "kia", model = "rio"))
         storage.add(CarStreamType, "car-123", 2, CarSoldEvent(seller = 1, buyer = 2, 2500.00f))
 
         // when
-        val eventStore = factory.createEventStore(storage)
+        val eventStore = factory.newEventStore(storage)
 
         (0..1).forEach { sinceVersion ->
             val eventEnvelopes = eventStore

--- a/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/StreamTestFactory.kt
+++ b/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/StreamTestFactory.kt
@@ -3,7 +3,25 @@ package dev.eskt.store.test
 import dev.eskt.store.api.EventStore
 import dev.eskt.store.storage.api.Storage
 
-public interface StreamTestFactory<R : Storage, S : EventStore> {
-    public fun createStorage(): R
-    public fun createEventStore(storage: R): S
+public abstract class StreamTestFactory<R : Storage, S : EventStore> {
+
+    private val _stores: MutableList<S> = mutableListOf()
+    public val stores: List<S>
+        get() = _stores
+
+    public fun clear() {
+        _stores.clear()
+    }
+
+    protected abstract fun createStorage(): R
+
+    public fun newStorage(): R {
+        return createStorage()
+    }
+
+    protected abstract fun createEventStore(storage: R): S
+
+    public fun newEventStore(storage: R): S {
+        return createEventStore(storage).also { _stores.add(it) }
+    }
 }


### PR DESCRIPTION
Future implementations of the event store such as the PostgreSQL one will need to close the stores created for testing, so for now the test factory needs to provide a collection to allow those stores to be manipulated.