### PR TITLE
feat(pg): drop support for different tables per stream type

### DIFF
--- a/event-store/api/src/commonMain/kotlin/dev/eskt/store/api/DatabaseStreamType.kt
+++ b/event-store/api/src/commonMain/kotlin/dev/eskt/store/api/DatabaseStreamType.kt
@@ -1,6 +1,0 @@
-package dev.eskt.store.api
-
-public interface DatabaseStreamType<I, E> : StreamType<I, E> {
-    public val eventTableSchema: String
-    public val eventTableName: String
-}

--- a/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/DatabaseAdapter.kt
+++ b/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/DatabaseAdapter.kt
@@ -5,19 +5,19 @@ internal expect class DatabaseAdapter(
 ) {
     fun getEntryByPosition(
         position: Long,
-        tableInfos: List<StreamTypeTableInfo>,
+        tableInfo: TableInfo,
     ): PostgresqlStorage.DatabaseEntry
 
     fun getEntriesByStreamIdAndVersion(
         streamId: String,
         sinceVersion: Int,
         limit: Int = Int.MAX_VALUE,
-        tableInfos: List<StreamTypeTableInfo>,
+        tableInfo: TableInfo,
     ): List<PostgresqlStorage.DatabaseEntry>
 
     fun persistEntries(
         entries: List<PostgresqlStorage.DatabaseEntry>,
-        tableInfo: StreamTypeTableInfo,
+        tableInfo: TableInfo,
     )
 
     fun close()

--- a/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/PostgresqlEventStore.kt
+++ b/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/PostgresqlEventStore.kt
@@ -10,9 +10,10 @@ public class PostgresqlEventStore internal constructor(
 ) : EventStore {
     public constructor(
         connectionConfig: ConnectionConfig,
+        eventTable: String,
         block: PostgresqlConfigBuilder.() -> Unit,
     ) : this(
-        PostgresqlConfigBuilder(connectionConfig)
+        PostgresqlConfigBuilder(connectionConfig, eventTable)
             .apply(block)
             .build(),
     )

--- a/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/PostgresqlStorage.kt
+++ b/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/PostgresqlStorage.kt
@@ -25,32 +25,29 @@ internal class PostgresqlStorage(
             )
         }
 
-        databaseAdapter.persistEntries(entries, config.streamTypeTableInfoInfoById.getValue(streamType.id))
+        databaseAdapter.persistEntries(entries, config.tableInfo)
     }
 
     override fun <I, E> getStreamEvents(streamId: I, sinceVersion: Int): List<EventEnvelope<I, E>> {
-        val tableInfo = config.streamTypeTableInfoInfoById.values.distinct()
         val entries = databaseAdapter.getEntriesByStreamIdAndVersion(
             streamId = streamId.toString(),
             sinceVersion = sinceVersion,
-            tableInfos = tableInfo,
+            tableInfo = config.tableInfo,
         )
         return entries.map { entry -> entry.toEventEnvelope() }
     }
 
     override fun <I, E> getEventByPosition(position: Long): EventEnvelope<I, E> {
-        val tableInfo = config.streamTypeTableInfoInfoById.values.distinct()
-        val entry = databaseAdapter.getEntryByPosition(position, tableInfo)
+        val entry = databaseAdapter.getEntryByPosition(position, config.tableInfo)
         return entry.toEventEnvelope()
     }
 
     override fun <I, E> getEventByStreamVersion(streamId: I, version: Int): EventEnvelope<I, E> {
-        val tableInfo = config.streamTypeTableInfoInfoById.values.distinct()
         val entry = databaseAdapter.getEntriesByStreamIdAndVersion(
             streamId = streamId.toString(),
             sinceVersion = version - 1,
             limit = 1,
-            tableInfos = tableInfo,
+            tableInfo = config.tableInfo,
         ).single()
         return entry.toEventEnvelope()
     }

--- a/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/queries.kt
+++ b/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/queries.kt
@@ -1,23 +1,23 @@
 package dev.eskt.store.impl.pg
 
-internal fun selectEventByPositionSql(schema: String, eventTable: String) = """
-    select position, stream_type, stream_id, version, payload, metadata from $schema.$eventTable
+internal fun selectEventByPositionSql(eventTable: String) = """
+    select position, stream_type, stream_id, version, payload, metadata from $eventTable
     where position = ?;
     """.trimIndent()
 
-internal fun selectMaxVersionByStreamIdSql(schema: String, eventTable: String) = """
-    select max(version) from $schema.$eventTable
+internal fun selectMaxVersionByStreamIdSql(eventTable: String) = """
+    select max(version) from $eventTable
     where stream_id = ?;
     """.trimIndent()
 
-internal fun selectEventByStreamIdAndVersionSql(schema: String, eventTable: String) = """
-    select position, stream_type, stream_id, version, payload, metadata from $schema.$eventTable
+internal fun selectEventByStreamIdAndVersionSql(eventTable: String) = """
+    select position, stream_type, stream_id, version, payload, metadata from $eventTable
     where stream_id = ? and version > ?
     order by version asc
     limit ?;
     """.trimIndent()
 
-internal fun insertEventSql(schema: String, eventTable: String, columnType: String) = """
-    insert into $schema.$eventTable (stream_type, stream_id, version, payload, metadata)
+internal fun insertEventSql(eventTable: String, columnType: String) = """
+    insert into $eventTable (stream_type, stream_id, version, payload, metadata)
     values (?, ?, ?, ?::$columnType, ?::$columnType);    
     """.trimIndent()

--- a/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/PostgresqlAppendStreamTest.kt
+++ b/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/PostgresqlAppendStreamTest.kt
@@ -15,6 +15,7 @@ internal class PostgresqlAppendStreamTest : AppendStreamTest<PostgresqlStorage, 
             ),
             eventMetadataSerializer = DefaultEventMetadataSerializer,
             connectionConfig = generateTestConnectionConfig(),
+            eventTable = "event",
         )
 
         override fun createStorage(): PostgresqlStorage {

--- a/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/PostgresqlLoadStreamTest.kt
+++ b/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/PostgresqlLoadStreamTest.kt
@@ -15,6 +15,7 @@ internal class PostgresqlLoadStreamTest : LoadStreamTest<PostgresqlStorage, Post
             ),
             eventMetadataSerializer = DefaultEventMetadataSerializer,
             connectionConfig = generateTestConnectionConfig(),
+            eventTable = "event",
         )
 
         override fun createStorage(): PostgresqlStorage {

--- a/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/config.kt
+++ b/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/config.kt
@@ -6,7 +6,7 @@ internal fun generateTestConnectionConfig() = ConnectionConfig(
     host = "localhost",
     port = 5432,
     database = "test_${Random.nextInt(0, 2000000000)}",
-    schema = "public",
+    schema = "event_store",
     user = "postgres",
     pass = "postgres",
 )

--- a/event-store/impl-postgresql/src/jvmMain/kotlin/dev/eskt/store/impl/pg/hikari.kt
+++ b/event-store/impl-postgresql/src/jvmMain/kotlin/dev/eskt/store/impl/pg/hikari.kt
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariConfig
 
 internal fun ConnectionConfig.toHikariConfig(): HikariConfig = HikariConfig().apply {
     jdbcUrl = "jdbc:postgresql://${this@toHikariConfig.host}:${this@toHikariConfig.port}/${this@toHikariConfig.database}"
+    schema = this@toHikariConfig.schema
     username = this@toHikariConfig.user
     password = this@toHikariConfig.pass
     minimumIdle = this@toHikariConfig.minPoolSize

--- a/event-store/impl-postgresql/src/jvmTest/kotlin/dev/eskt/store/impl/pg/PostgresqlEventStorePublicConstructorTest.kt
+++ b/event-store/impl-postgresql/src/jvmTest/kotlin/dev/eskt/store/impl/pg/PostgresqlEventStorePublicConstructorTest.kt
@@ -1,0 +1,15 @@
+package dev.eskt.store.impl.pg
+
+import dev.eskt.store.test.w.car.CarStreamType
+import org.junit.Test
+
+internal class PostgresqlEventStorePublicConstructorTest {
+    @Test
+    fun `public constructor creates event store and allow withStreamType to be called`() {
+        val eventStore = PostgresqlEventStore(generateTestConnectionConfig(), "new_events") {
+            registerStreamType(CarStreamType)
+        }
+
+        eventStore.withStreamType(CarStreamType)
+    }
+}

--- a/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/w/car/CarStreamType.kt
+++ b/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/w/car/CarStreamType.kt
@@ -1,7 +1,6 @@
 package dev.eskt.store.test.w.car
 
 import dev.eskt.store.api.BinarySerializableStreamType
-import dev.eskt.store.api.DatabaseStreamType
 import dev.eskt.store.api.Serializer
 import dev.eskt.store.api.StreamType
 import dev.eskt.store.api.StringSerializableStreamType
@@ -13,12 +12,9 @@ import kotlinx.serialization.json.Json
 public object CarStreamType :
     StreamType<String, CarEvent>,
     BinarySerializableStreamType<String, CarEvent>,
-    StringSerializableStreamType<String, CarEvent>,
-    DatabaseStreamType<String, CarEvent> {
-    private val eventSerializer = CarEvent.serializer()
+    StringSerializableStreamType<String, CarEvent> {
 
-    override val eventTableSchema: String = "event_store"
-    override val eventTableName: String = "event_1"
+    private val eventSerializer = CarEvent.serializer()
 
     override val id: String = "Car"
 


### PR DESCRIPTION
Support multiple event tables would have its limitations anyway, as we wouldn't have a single sequence anyway, and on a second analysis I think it's better to simplify the implementation for now.