### PR TITLE
feat(hex-arch): add EventListener port and spring support

### DIFF
--- a/app-examples/car-management-hexagonal-arch/domain/build.gradle.kts
+++ b/app-examples/car-management-hexagonal-arch/domain/build.gradle.kts
@@ -23,5 +23,10 @@ kotlin {
                 api("com.benasher44:uuid:0.8.2")
             }
         }
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/EventListener.kt
+++ b/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/EventListener.kt
@@ -1,0 +1,3 @@
+package dev.eskt.example.domain
+
+annotation class EventListener

--- a/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/process/CarProductionNotificationProcess.kt
+++ b/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/process/CarProductionNotificationProcess.kt
@@ -1,0 +1,25 @@
+package dev.eskt.example.domain.process
+
+import com.benasher44.uuid.Uuid
+import dev.eskt.arch.hex.port.SingleStreamTypeEventListener
+import dev.eskt.example.domain.EventListener
+import dev.eskt.store.api.EventEnvelope
+import dev.eskt.store.api.StreamType
+import dev.eskt.store.test.w.car.CarEvent
+import dev.eskt.store.test.w.car.CarProducedEvent
+import dev.eskt.store.test.w.car.CarStreamType
+
+@EventListener
+class CarProductionNotificationProcess(
+    private val notifier: CarProductionNotifier,
+) : SingleStreamTypeEventListener<CarEvent, Uuid> {
+    override val id: String = "car-production-notification-process"
+    override val streamType: StreamType<Uuid, CarEvent> = CarStreamType
+
+    override fun listen(envelope: EventEnvelope<Uuid, CarEvent>) {
+        when (val event = envelope.event) {
+            is CarProducedEvent -> notifier.notify(vin = event.vin, make = event.make, model = event.model)
+            else -> {}
+        }
+    }
+}

--- a/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/process/CarProductionNotifier.kt
+++ b/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/process/CarProductionNotifier.kt
@@ -1,0 +1,5 @@
+package dev.eskt.example.domain.process
+
+interface CarProductionNotifier {
+    fun notify(vin: String, make: String, model: String)
+}

--- a/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/query/CarCountEventListener.kt
+++ b/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/query/CarCountEventListener.kt
@@ -1,0 +1,48 @@
+package dev.eskt.example.domain.query
+
+import com.benasher44.uuid.Uuid
+import dev.eskt.arch.hex.port.SingleStreamTypeEventListener
+import dev.eskt.example.domain.EventListener
+import dev.eskt.store.api.EventEnvelope
+import dev.eskt.store.api.StreamType
+import dev.eskt.store.test.w.car.CarEliminatedEvent
+import dev.eskt.store.test.w.car.CarEvent
+import dev.eskt.store.test.w.car.CarProducedEvent
+import dev.eskt.store.test.w.car.CarStreamType
+
+@EventListener
+class CarCountEventListener(
+    private val makeModelCarCountRepository: MakeModelCarCountRepository,
+    private val makeModelCarRepository: MakeModelCarRepository,
+) : SingleStreamTypeEventListener<CarEvent, Uuid> {
+    override val id: String = "car-count-read-model"
+    override val streamType: StreamType<Uuid, CarEvent> = CarStreamType
+
+    override fun listen(envelope: EventEnvelope<Uuid, CarEvent>) {
+        when (val event = envelope.event) {
+            is CarProducedEvent -> {
+                val car = makeModelCarRepository.find(envelope.streamId)
+                if (car != null) return // already processed
+                makeModelCarRepository.add(MakeModelCar(id = envelope.streamId, make = event.make, model = event.model))
+
+                val makeModelCount = makeModelCarCountRepository.find(make = event.make, model = event.model)
+                    ?: MakeModelCarCount(make = event.make, model = event.model, count = 0)
+
+                makeModelCarCountRepository.save(makeModelCount.copy(count = makeModelCount.count + 1))
+            }
+
+            is CarEliminatedEvent -> {
+                val car = makeModelCarRepository.find(envelope.streamId)
+                    ?: return // already processed
+                makeModelCarRepository.removeById(envelope.streamId)
+
+                val makeModelCount = makeModelCarCountRepository.find(make = car.make, model = car.model)
+                    ?: throw IllegalStateException("Count should exist as car ${envelope.streamId} is being eliminated")
+
+                makeModelCarCountRepository.save(makeModelCount.copy(count = makeModelCount.count - 1))
+            }
+
+            else -> {}
+        }
+    }
+}

--- a/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/query/car-count-read-model.kt
+++ b/app-examples/car-management-hexagonal-arch/domain/src/commonMain/kotlin/dev/eskt/example/domain/query/car-count-read-model.kt
@@ -1,0 +1,28 @@
+package dev.eskt.example.domain.query
+
+import com.benasher44.uuid.Uuid
+
+
+data class MakeModelCar(
+    val id: Uuid,
+    val make: String,
+    val model: String,
+)
+
+interface MakeModelCarRepository {
+    fun find(id: Uuid): MakeModelCar?
+    fun add(car: MakeModelCar)
+    fun removeById(id: Uuid)
+}
+
+data class MakeModelCarCount(
+    val make: String,
+    val model: String,
+    val count: Int,
+)
+
+interface MakeModelCarCountRepository {
+    fun listAll(): List<MakeModelCarCount>
+    fun find(make: String, model: String): MakeModelCarCount?
+    fun save(carCount: MakeModelCarCount)
+}

--- a/app-examples/car-management-hexagonal-arch/domain/src/commonTest/kotlin/dev/eskt/example/domain/query/CarCountEventListenerTest.kt
+++ b/app-examples/car-management-hexagonal-arch/domain/src/commonTest/kotlin/dev/eskt/example/domain/query/CarCountEventListenerTest.kt
@@ -1,0 +1,202 @@
+package dev.eskt.example.domain.query
+
+import com.benasher44.uuid.Uuid
+import dev.eskt.store.api.EventEnvelope
+import dev.eskt.store.test.w.car.CarEliminatedEvent
+import dev.eskt.store.test.w.car.CarProducedEvent
+import dev.eskt.store.test.w.car.CarStreamType
+import dev.eskt.store.test.w.car.EliminationReason
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+internal class CarCountEventListenerTest {
+
+    @Test
+    fun `given no cars - when listening to first production event - then read model updates correctly`() {
+        // given
+        val countRepo = MakeModelCarCountMemoryRepository()
+        val carRepo = MakeModelCarMemoryRepository()
+
+        // when
+        val listener = CarCountEventListener(countRepo, carRepo)
+        listener.listen(
+            EventEnvelope(
+                streamType = CarStreamType, streamId = car1StreamId, version = 1, position = 1,
+                metadata = emptyMap(),
+                event = CarProducedEvent(
+                    vin = "2A4RR5D1XAR410299",
+                    make = "Kia",
+                    model = "Rio",
+                    producer = 1,
+                ),
+            ),
+        )
+
+        // then
+        assertEquals(1, countRepo.listAll().size)
+        assertEquals(1, countRepo.find("Kia", "Rio")?.count)
+        assertNotNull(carRepo.find(car1StreamId)).also { car ->
+            assertEquals("Kia", car.make)
+            assertEquals("Rio", car.model)
+        }
+    }
+
+    @Test
+    fun `given 1 car counted - when listening to the same production event - then nothing happens`() {
+        // given
+        val countRepo = MakeModelCarCountMemoryRepository(
+            MakeModelCarCount("Kia", "Rio", 1),
+        )
+        val carRepo = MakeModelCarMemoryRepository(
+            MakeModelCar(car1StreamId, "Kia", "Rio"),
+        )
+
+        // when
+        val listener = CarCountEventListener(countRepo, carRepo)
+        listener.listen(
+            EventEnvelope(
+                streamType = CarStreamType, streamId = car1StreamId, version = 1, position = 1,
+                metadata = emptyMap(),
+                event = CarProducedEvent(
+                    vin = "2A4RR5D1XAR410299",
+                    make = "Kia",
+                    model = "Rio",
+                    producer = 1,
+                ),
+            ),
+        )
+
+        // then
+        assertEquals(1, countRepo.listAll().size)
+        assertEquals(1, countRepo.find("Kia", "Rio")?.count)
+        assertNotNull(carRepo.find(car1StreamId)).also { car ->
+            assertEquals("Kia", car.make)
+            assertEquals("Rio", car.model)
+        }
+    }
+
+    @Test
+    fun `given 1 car counted - when listening to second production event - then read model updates correctly`() {
+        // given
+        val countRepo = MakeModelCarCountMemoryRepository(
+            MakeModelCarCount("Kia", "Rio", 1),
+        )
+        val carRepo = MakeModelCarMemoryRepository(
+            MakeModelCar(car1StreamId, "Kia", "Rio"),
+        )
+
+        // when
+        val listener = CarCountEventListener(countRepo, carRepo)
+        listener.listen(
+            EventEnvelope(
+                streamType = CarStreamType, streamId = car2StreamId, version = 1, position = 2,
+                metadata = emptyMap(),
+                event = CarProducedEvent(
+                    vin = "1J8HG48K67C669063",
+                    make = "Kia",
+                    model = "Rio",
+                    producer = 5,
+                ),
+            ),
+        )
+
+        // then
+        assertEquals(1, countRepo.listAll().size)
+        assertEquals(2, countRepo.find("Kia", "Rio")?.count)
+        assertNotNull(carRepo.find(car2StreamId)).also { car ->
+            assertEquals("Kia", car.make)
+            assertEquals("Rio", car.model)
+        }
+    }
+
+    @Test
+    fun `given 1 car counted - when listening to the same car being eliminated - then read model updates correctly`() {
+        // given
+        val countRepo = MakeModelCarCountMemoryRepository(
+            MakeModelCarCount("Kia", "Rio", 1),
+        )
+        val carRepo = MakeModelCarMemoryRepository(
+            MakeModelCar(car1StreamId, "Kia", "Rio"),
+        )
+
+        // when
+        val listener = CarCountEventListener(countRepo, carRepo)
+        listener.listen(
+            EventEnvelope(
+                streamType = CarStreamType, streamId = car1StreamId, version = 2, position = 2,
+                metadata = emptyMap(),
+                event = CarEliminatedEvent(
+                    reason = EliminationReason.Lost,
+                ),
+            ),
+        )
+
+        // then
+        assertEquals(1, countRepo.listAll().size)
+        assertEquals(0, countRepo.find("Kia", "Rio")?.count)
+        assertNull(carRepo.find(car1StreamId))
+    }
+
+    @Test
+    fun `given 2 cars counted - when listening to second production event - then read model updates correctly`() {
+        // given
+        val countRepo = MakeModelCarCountMemoryRepository(
+            MakeModelCarCount("Kia", "Rio", 2),
+        )
+        val carRepo = MakeModelCarMemoryRepository(
+            MakeModelCar(car1StreamId, "Kia", "Rio"),
+            MakeModelCar(car2StreamId, "Kia", "Rio"),
+        )
+
+        // when
+        val listener = CarCountEventListener(countRepo, carRepo)
+        listener.listen(
+            EventEnvelope(
+                streamType = CarStreamType, streamId = car3StreamId, version = 1, position = 3,
+                metadata = emptyMap(),
+                event = CarProducedEvent(
+                    vin = "1J4NT1GA3BD184938",
+                    make = "Toyota",
+                    model = "Corolla",
+                    producer = 17,
+                ),
+            ),
+        )
+
+        // then
+        assertEquals(2, countRepo.listAll().size)
+        assertEquals(1, countRepo.find("Toyota", "Corolla")?.count)
+        assertNotNull(carRepo.find(car3StreamId)).also { car ->
+            assertEquals("Toyota", car.make)
+            assertEquals("Corolla", car.model)
+        }
+    }
+
+    class MakeModelCarCountMemoryRepository(vararg initialCars: MakeModelCarCount) : MakeModelCarCountRepository {
+        private val cars = mutableListOf(*initialCars)
+
+        override fun listAll(): List<MakeModelCarCount> = cars.toList()
+        override fun find(make: String, model: String): MakeModelCarCount? = cars.singleOrNull { it.make == make && it.model == model }
+
+        override fun save(carCount: MakeModelCarCount) {
+            cars.removeAll { it.make == carCount.make && it.model == carCount.model }
+            cars.add(carCount)
+        }
+    }
+
+    class MakeModelCarMemoryRepository(vararg initialCars: MakeModelCar) : MakeModelCarRepository {
+        private val cars = mutableListOf(*initialCars)
+
+        override fun find(id: Uuid): MakeModelCar? = cars.singleOrNull { it.id == id }
+
+        override fun add(car: MakeModelCar) {
+            cars.add(car)
+        }
+
+        override fun removeById(id: Uuid) {
+            cars.removeAll { it.id == id }
+        }
+    }
+}

--- a/app-examples/car-management-hexagonal-arch/domain/src/commonTest/kotlin/dev/eskt/example/domain/query/CarProductionNotificationProcessTest.kt
+++ b/app-examples/car-management-hexagonal-arch/domain/src/commonTest/kotlin/dev/eskt/example/domain/query/CarProductionNotificationProcessTest.kt
@@ -1,0 +1,41 @@
+package dev.eskt.example.domain.query
+
+import dev.eskt.example.domain.process.CarProductionNotificationProcess
+import dev.eskt.example.domain.process.CarProductionNotifier
+import dev.eskt.store.api.EventEnvelope
+import dev.eskt.store.test.w.car.CarProducedEvent
+import dev.eskt.store.test.w.car.CarStreamType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CarProductionNotificationProcessTest {
+
+    @Test
+    fun `given no cars - when listening production event - then notifier is called correctly`() {
+        // given
+
+        // when
+        lateinit var notifiedVin: String
+        val notifier = object : CarProductionNotifier {
+            override fun notify(vin: String, make: String, model: String) {
+                notifiedVin = vin
+            }
+        }
+        val listener = CarProductionNotificationProcess(notifier)
+        listener.listen(
+            EventEnvelope(
+                streamType = CarStreamType, streamId = car1StreamId, version = 1, position = 1,
+                metadata = emptyMap(),
+                event = CarProducedEvent(
+                    vin = "2A4RR5D1XAR410299",
+                    make = "Kia",
+                    model = "Rio",
+                    producer = 1,
+                ),
+            ),
+        )
+
+        // then
+        assertEquals("2A4RR5D1XAR410299", notifiedVin)
+    }
+}

--- a/app-examples/car-management-hexagonal-arch/domain/src/commonTest/kotlin/dev/eskt/example/domain/query/_wellKnown.kt
+++ b/app-examples/car-management-hexagonal-arch/domain/src/commonTest/kotlin/dev/eskt/example/domain/query/_wellKnown.kt
@@ -1,0 +1,7 @@
+package dev.eskt.example.domain.query
+
+import com.benasher44.uuid.uuidFrom
+
+internal val car1StreamId = uuidFrom("9a024ac0-246d-449f-9229-229ad05a70b0")
+internal val car2StreamId = uuidFrom("84eb4461-8e1e-4a93-9438-6ec7ffadc10b")
+internal val car3StreamId = uuidFrom("b289e3fa-1c79-49a8-b4b1-2ea3b507f871")

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/build.gradle.kts
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     // project
     implementation(project(":domain"))
     implementation("dev.eskt:impl-postgresql")
+    implementation("dev.eskt:hex-arch-adapters-spring6")
 
     // runtime
 	runtimeOnly("com.h2database:h2")

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/ApplicationDomainConfig.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/ApplicationDomainConfig.kt
@@ -1,5 +1,6 @@
 package dev.eskt.example.app
 
+import dev.eskt.example.domain.EventListener
 import dev.eskt.example.domain.UseCase
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
@@ -15,6 +16,7 @@ import org.springframework.context.annotation.FilterType
             type = FilterType.ANNOTATION,
             classes = [
                 UseCase::class,
+                EventListener::class,
             ],
         ),
     ],

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/ApplicationEventStoreConfig.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/ApplicationEventStoreConfig.kt
@@ -4,10 +4,16 @@ import dev.eskt.store.api.EventStore
 import dev.eskt.store.impl.pg.PostgresqlEventStore
 import dev.eskt.store.test.w.car.CarStreamType
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import javax.sql.DataSource
 
 @Configuration
+@ComponentScan(
+    basePackages = [
+        "dev.eskt.arch.hex.adapter.spring",
+    ],
+)
 class ApplicationEventStoreConfig {
     @Bean
     fun eventStore(dataSource: DataSource): EventStore {

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/CarController.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/CarController.kt
@@ -12,12 +12,12 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class CarController(
     val carProduction: CarProduction,
-    val carCountReadModelRepository: MakeModelCarCountRepository,
+    val carCountRepository: MakeModelCarCountRepository,
 ) {
 
     @GetMapping("/car-count/summary")
     fun getCarCountSummary(): List<CarCount> {
-        return carCountReadModelRepository.listAll().map {
+        return carCountRepository.listAll().map {
             CarCount(
                 make = it.make,
                 model = it.model,

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/CarController.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/CarController.kt
@@ -3,6 +3,8 @@ package dev.eskt.example.app
 import com.benasher44.uuid.uuidFrom
 import dev.eskt.example.domain.CarProduction
 import dev.eskt.example.domain.command.CarCommand
+import dev.eskt.example.domain.query.MakeModelCarCountRepository
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -10,7 +12,20 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class CarController(
     val carProduction: CarProduction,
+    val carCountReadModelRepository: MakeModelCarCountRepository,
 ) {
+
+    @GetMapping("/car-count/summary")
+    fun getCarCountSummary(): List<CarCount> {
+        return carCountReadModelRepository.listAll().map {
+            CarCount(
+                make = it.make,
+                model = it.model,
+                count = it.count,
+            )
+        }
+    }
+
     @PostMapping("/cars")
     fun postCar(
         @RequestBody body: ProduceCarRequest,
@@ -32,5 +47,11 @@ class CarController(
         val producer: Long,
         val make: String,
         val model: String,
+    )
+
+    data class CarCount(
+        val make: String,
+        val model: String,
+        val count: Int,
     )
 }

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/bookmark/BookmarkEntity.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/bookmark/BookmarkEntity.kt
@@ -1,0 +1,13 @@
+package dev.eskt.example.app.bookmark
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Table(name = "bookmark")
+@Entity
+data class BookmarkEntity(
+    @Id
+    val id: String,
+    val value: Long,
+)

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/bookmark/BookmarkRepository.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/bookmark/BookmarkRepository.kt
@@ -1,0 +1,15 @@
+package dev.eskt.example.app.bookmark
+
+import dev.eskt.arch.hex.adapter.common.Bookmark
+import org.springframework.data.jpa.repository.JpaRepository
+import kotlin.jvm.optionals.getOrNull
+
+interface BookmarkRepository: JpaRepository<BookmarkEntity, String>, Bookmark {
+    override fun get(id: String): Long {
+        return findById(id).getOrNull()?.value ?: 0L
+    }
+
+    override fun set(id: String, value: Long) {
+        save(BookmarkEntity(id, value))
+    }
+}

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/process/CarProductionLogNotifier.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/process/CarProductionLogNotifier.kt
@@ -1,0 +1,11 @@
+package dev.eskt.example.app.process
+
+import dev.eskt.example.domain.process.CarProductionNotifier
+import org.springframework.stereotype.Component
+
+@Component
+class CarProductionLogNotifier : CarProductionNotifier {
+    override fun notify(vin: String, make: String, model: String) {
+        println("produced $make $model car with VIN $vin")
+    }
+}

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarCountEntity.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarCountEntity.kt
@@ -1,0 +1,21 @@
+package dev.eskt.example.app.query
+
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.io.Serializable
+
+@Entity
+@Table(name = "car_count_rm__car_count")
+data class MakeModelCarCountEntity(
+    @EmbeddedId
+    val id: Id,
+    val count: Int,
+) {
+    data class Id(
+        val make: String,
+        val model: String,
+    ) : Serializable {
+        constructor() : this("", "")
+    }
+}

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarCountJpaRepository.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarCountJpaRepository.kt
@@ -1,0 +1,26 @@
+package dev.eskt.example.app.query
+
+import dev.eskt.example.domain.query.MakeModelCarCount
+import dev.eskt.example.domain.query.MakeModelCarCountRepository
+import org.springframework.data.jpa.repository.JpaRepository
+import kotlin.jvm.optionals.getOrNull
+
+interface MakeModelCarCountJpaRepository : JpaRepository<MakeModelCarCountEntity, MakeModelCarCountEntity.Id>, MakeModelCarCountRepository {
+    override fun listAll(): List<MakeModelCarCount> {
+        return findAll().map { it.toDomain() }
+    }
+
+    override fun find(make: String, model: String): MakeModelCarCount? {
+        return findById(MakeModelCarCountEntity.Id(make, model)).getOrNull()?.toDomain()
+    }
+
+    override fun save(carCount: MakeModelCarCount) {
+        save(MakeModelCarCountEntity(MakeModelCarCountEntity.Id(make = carCount.make, model = carCount.model), count = carCount.count))
+    }
+
+    private fun MakeModelCarCountEntity.toDomain() = MakeModelCarCount(
+        make = id.make,
+        model = id.model,
+        count = count,
+    )
+}

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarCountJpaRepository.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarCountJpaRepository.kt
@@ -15,7 +15,7 @@ interface MakeModelCarCountJpaRepository : JpaRepository<MakeModelCarCountEntity
     }
 
     override fun save(carCount: MakeModelCarCount) {
-        save(MakeModelCarCountEntity(MakeModelCarCountEntity.Id(make = carCount.make, model = carCount.model), count = carCount.count))
+        save(carCount.toEntity())
     }
 
     private fun MakeModelCarCountEntity.toDomain() = MakeModelCarCount(
@@ -23,4 +23,11 @@ interface MakeModelCarCountJpaRepository : JpaRepository<MakeModelCarCountEntity
         model = id.model,
         count = count,
     )
+
+    private fun MakeModelCarCount.toEntity(): MakeModelCarCountEntity {
+        return MakeModelCarCountEntity(
+            id = MakeModelCarCountEntity.Id(make = make, model = model),
+            count = count,
+        )
+    }
 }

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarEntity.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarEntity.kt
@@ -1,0 +1,15 @@
+package dev.eskt.example.app.query
+
+import com.benasher44.uuid.Uuid
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "car_count_rm__car")
+data class MakeModelCarEntity(
+    @Id
+    val id: Uuid,
+    val make: String,
+    val model: String,
+)

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarJpaRepository.kt
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/kotlin/dev/eskt/example/app/query/MakeModelCarJpaRepository.kt
@@ -1,0 +1,22 @@
+package dev.eskt.example.app.query
+
+import com.benasher44.uuid.Uuid
+import dev.eskt.example.domain.query.MakeModelCar
+import dev.eskt.example.domain.query.MakeModelCarRepository
+import org.springframework.data.jpa.repository.JpaRepository
+import kotlin.jvm.optionals.getOrNull
+
+interface MakeModelCarJpaRepository : JpaRepository<MakeModelCarEntity, Uuid>, MakeModelCarRepository {
+
+    override fun find(id: Uuid): MakeModelCar? {
+        return findById(id).getOrNull()?.let { MakeModelCar(id = it.id, make = it.make, model = it.model) }
+    }
+
+    override fun add(car: MakeModelCar) {
+        save(MakeModelCarEntity(id = car.id, make = car.make, model = car.model))
+    }
+
+    override fun removeById(id: Uuid) {
+        deleteById(id)
+    }
+}

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/resources/db/migration/V3_0__car_count_rm.sql
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/resources/db/migration/V3_0__car_count_rm.sql
@@ -1,0 +1,15 @@
+CREATE TABLE car_count_rm__car
+(
+    id    uuid NOT NULL PRIMARY KEY,
+    make  text NOT NULL,
+    model text NOT NULL
+);
+
+
+CREATE TABLE car_count_rm__car_count
+(
+    make  text NOT NULL,
+    model text NOT NULL,
+    count int  not null,
+    primary key (make, model)
+);

--- a/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/resources/db/migration/V4_0__bookmark.sql
+++ b/app-examples/car-management-hexagonal-arch/spring-webflux-jpa-application/src/main/resources/db/migration/V4_0__bookmark.sql
@@ -1,0 +1,5 @@
+CREATE TABLE bookmark
+(
+    id    text   NOT NULL PRIMARY KEY,
+    value bigint NOT NULL
+);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,8 @@
 kotlinx-coroutines = "1.7.2"
 kotlinx-serialization = "1.5.1"
 kotlinx-atomicfu = "0.21.0"
+slf4j = "1.7.36"
+spring6 = "6.0.14"
 uuid = "0.8.2"
 okio = "3.5.0"
 postgresql-jdbc = "42.6.0"
@@ -23,6 +25,12 @@ uuid = { group = "com.benasher44", name = "uuid", version.ref = "uuid" }
 
 okio-core = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
 okio-node = { group = "com.squareup.okio", name = "okio-nodefilesystem", version.ref = "okio" }
+
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+
+spring6-context = { group = "org.springframework", name = "spring-context", version.ref = "spring6" }
+spring6-beans = { group = "org.springframework", name = "spring-beans", version.ref = "spring6" }
+spring6-tx = { group = "org.springframework", name = "spring-tx", version.ref = "spring6" }
 
 postgresql-jdbc = { group = "org.postgresql", name = "postgresql", version.ref = "postgresql-jdbc" }
 hikaricp = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikaricp" }

--- a/hex-arch-adapters-common/build.gradle.kts
+++ b/hex-arch-adapters-common/build.gradle.kts
@@ -11,9 +11,11 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":event-store:api"))
+                api(project(":hex-arch-ports"))
+                api(libs.kotlinx.coroutines.core)
             }
         }
     }
 }
 
-setupPublishing("hex-arch-ports")
+setupPublishing("hex-arch-adapters-common")

--- a/hex-arch-adapters-common/src/commonMain/kotlin/dev/eskt/arch/hex/adapter/common/Bookmark.kt
+++ b/hex-arch-adapters-common/src/commonMain/kotlin/dev/eskt/arch/hex/adapter/common/Bookmark.kt
@@ -1,0 +1,6 @@
+package dev.eskt.arch.hex.adapter.common
+
+public interface Bookmark {
+    public fun get(id: String): Long
+    public fun set(id: String, value: Long)
+}

--- a/hex-arch-adapters-common/src/commonMain/kotlin/dev/eskt/arch/hex/adapter/common/event-processor.kt
+++ b/hex-arch-adapters-common/src/commonMain/kotlin/dev/eskt/arch/hex/adapter/common/event-processor.kt
@@ -1,0 +1,25 @@
+package dev.eskt.arch.hex.adapter.common
+
+import dev.eskt.store.api.EventEnvelope
+import dev.eskt.store.api.EventStore
+import dev.eskt.store.api.StreamType
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+
+public suspend inline fun <E, I> EventStore.singleStreamTypeEventFlow(
+    streamType: StreamType<I, E>,
+    sincePosition: Long,
+    batchSize: Int,
+): Flow<EventEnvelope<I, E>> = channelFlow {
+    var lastPosition = sincePosition
+    while (true) {
+        val eventBatch = loadEventBatch(lastPosition, batchSize, streamType = streamType)
+        eventBatch.forEach {
+            this.send(it)
+            lastPosition = it.position
+        }
+        if (eventBatch.isEmpty()) delay(500)
+        if (eventBatch.size < batchSize) delay(250)
+    }
+}

--- a/hex-arch-adapters-spring6/build.gradle.kts
+++ b/hex-arch-adapters-spring6/build.gradle.kts
@@ -1,0 +1,49 @@
+import java.net.URI
+
+plugins {
+    kotlin("jvm")
+    id("maven-publish")
+}
+
+group = "dev.eskt"
+
+kotlin {
+    jvmToolchain(17)
+    explicitApi()
+}
+
+java {
+    withSourcesJar()
+}
+
+dependencies {
+    api(project(":event-store:api"))
+    api(project(":hex-arch-ports"))
+    api(project(":hex-arch-adapters-common"))
+
+    implementation(libs.slf4j.api)
+    implementation(libs.kotlinx.coroutines.core)
+
+    compileOnly(libs.spring6.context)
+    compileOnly(libs.spring6.beans)
+    compileOnly(libs.spring6.tx)
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            artifactId = "hex-arch-adapters-spring6"
+            from(components["java"])
+        }
+    }
+    repositories {
+        // from https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-gradle#publishing-packages-to-github-packages
+        maven {
+            url = URI("https://maven.pkg.github.com/eskt-dev/eskt")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}

--- a/hex-arch-adapters-spring6/src/main/kotlin/dev/eskt/arch/hex/adapter/spring/EventListenerExecutorService.kt
+++ b/hex-arch-adapters-spring6/src/main/kotlin/dev/eskt/arch/hex/adapter/spring/EventListenerExecutorService.kt
@@ -1,0 +1,88 @@
+package dev.eskt.arch.hex.adapter.spring
+
+import dev.eskt.arch.hex.adapter.common.Bookmark
+import dev.eskt.arch.hex.adapter.common.singleStreamTypeEventFlow
+import dev.eskt.arch.hex.port.SingleStreamTypeEventListener
+import dev.eskt.store.api.EventStore
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newFixedThreadPoolContext
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionTemplate
+import kotlin.time.Duration.Companion.seconds
+
+@Component
+public class EventListenerExecutorService(
+    private val eventStore: EventStore,
+    private val bookmark: Bookmark,
+    private val transactionTemplate: TransactionTemplate,
+    private val eventListeners: List<SingleStreamTypeEventListener<*, *>>,
+) : InitializingBean, DisposableBean {
+    private val logger: Logger = LoggerFactory.getLogger(EventListenerExecutorService::class.java)
+
+    private val batchSize = 100
+    private val backoff = 15.seconds
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private val dispatcher = newFixedThreadPoolContext(4, "evt-listener")
+    private val supervisor = SupervisorJob()
+    private val scope = CoroutineScope(dispatcher + supervisor)
+
+    private var stopped = false
+
+    private fun init() {
+        logger.info("Starting listener processes for ${eventListeners.size} listeners...")
+        eventListeners.forEach { genericListener ->
+            @Suppress("UNCHECKED_CAST")
+            val eventListener = genericListener as SingleStreamTypeEventListener<Any, Any>
+            scope.launch {
+                while (!stopped) {
+                    logger.info("Starting collection of events for $eventListener")
+                    try {
+                        eventStore
+                            .singleStreamTypeEventFlow(
+                                streamType = eventListener.streamType,
+                                sincePosition = bookmark.get(eventListener.id),
+                                batchSize = batchSize,
+                            )
+                            .collect { envelope ->
+                                transactionTemplate.execute {
+                                    eventListener.listen(envelope)
+                                    bookmark.set(eventListener.id, envelope.position)
+                                }
+                                logger.info("Processed event position ${envelope.position} of type ${envelope.event::class.qualifiedName} in $eventListener")
+                            }
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
+                        logger.error("Error while collecting events in $eventListener, will try to restart in $backoff", e)
+                        if (!stopped) delay(backoff)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun shutdown() {
+        logger.info("Shutting down...")
+        stopped = true
+        supervisor.cancel("Shutting down")
+        dispatcher.close()
+    }
+
+    override fun afterPropertiesSet() {
+        init()
+    }
+
+    override fun destroy() {
+        shutdown()
+    }
+}

--- a/hex-arch-ports/src/commonMain/kotlin/dev/eskt/arch/hex/port/SingleStreamTypeEventListener.kt
+++ b/hex-arch-ports/src/commonMain/kotlin/dev/eskt/arch/hex/port/SingleStreamTypeEventListener.kt
@@ -1,0 +1,10 @@
+package dev.eskt.arch.hex.port
+
+import dev.eskt.store.api.EventEnvelope
+import dev.eskt.store.api.StreamType
+
+public interface SingleStreamTypeEventListener<E, I> {
+    public val id: String
+    public val streamType: StreamType<I, E>
+    public fun listen(envelope: EventEnvelope<I, E>)
+}

--- a/publish-jvm-local.sh
+++ b/publish-jvm-local.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-./gradlew -Pversion=local-SNAPSHOT publishJvmPublicationToMavenLocal
+./gradlew -Pversion=local-SNAPSHOT \
+   publishJvmPublicationToMavenLocal \
+   :hex-arch-ports:publishToMavenLocal \
+   :hex-arch-adapters-spring6:publishToMavenLocal \
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,3 +24,5 @@ include(":event-store:test-harness")
 include(":event-store:test-harness-model")
 
 include(":hex-arch-ports")
+include(":hex-arch-adapters-common")
+include(":hex-arch-adapters-spring6")


### PR DESCRIPTION
Adding `SingleStreamTypeEventListener` and basic support in Spring to run a very simple producer-consumer background process that reads events in batches and send them to the event listeners.