### PR TITLE
chore(gradle): force no daemon for the example build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,4 +37,4 @@ jobs:
         arguments: check
     - name: Build App Examples with Gradle
       working-directory: app-examples/car-management-hexagonal-arch
-      run: ./gradlew check
+      run: ./gradlew --no-daemon check


### PR DESCRIPTION
It executes last and reuses the previous daemon, which runs out of memory.