### PR TITLE
fix(event-store): use stream type id serializer on read methods

### DIFF
--- a/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/impl/common/base/StreamTypeHandler.kt
+++ b/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/impl/common/base/StreamTypeHandler.kt
@@ -13,7 +13,7 @@ public class StreamTypeHandler<E, I>(
     private val storage: Storage,
 ) : StreamTypeHandler<E, I> {
     override fun loadStream(streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>> {
-        return storage.getStreamEvents(streamId, sinceVersion)
+        return storage.getStreamEvents(streamType, streamId, sinceVersion)
     }
 
     override fun appendStream(streamId: I, expectedVersion: Int, events: List<E>, metadata: EventMetadata): Int {

--- a/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/storage/api/Storage.kt
+++ b/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/storage/api/Storage.kt
@@ -8,7 +8,7 @@ public interface Storage {
     @Throws(StorageVersionMismatchException::class)
     public fun <E, I> add(streamType: StreamType<E, I>, streamId: I, expectedVersion: Int, events: List<E>, metadata: EventMetadata)
 
-    public fun <E, I> getStreamEvents(streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>>
+    public fun <E, I> getStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>>
 
     public fun <E, I> getEventByPosition(position: Long): EventEnvelope<E, I>
 
@@ -16,5 +16,5 @@ public interface Storage {
 
     public fun <E, I> loadEventBatch(sincePosition: Long, batchSize: Int, streamType: StreamType<E, I>): List<EventEnvelope<E, I>>
 
-    public fun <E, I> getEventByStreamVersion(streamId: I, version: Int): EventEnvelope<E, I>
+    public fun <E, I> getEventByStreamVersion(streamType: StreamType<E, I>, streamId: I, version: Int): EventEnvelope<E, I>
 }

--- a/event-store/impl-memory/src/commonMain/kotlin/dev/eskt/store/impl/memory/InMemoryStorage.kt
+++ b/event-store/impl-memory/src/commonMain/kotlin/dev/eskt/store/impl/memory/InMemoryStorage.kt
@@ -19,7 +19,7 @@ internal class InMemoryStorage(
 
     private val writeLock = reentrantLock()
 
-    override fun <E, I> getStreamEvents(streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>> {
+    override fun <E, I> getStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>> {
         return events
             .filter { it.streamId == streamId }
             .drop(sinceVersion)
@@ -70,7 +70,7 @@ internal class InMemoryStorage(
             .toList()
     }
 
-    override fun <E, I> getEventByStreamVersion(streamId: I, version: Int): EventEnvelope<E, I> {
+    override fun <E, I> getEventByStreamVersion(streamType: StreamType<E, I>, streamId: I, version: Int): EventEnvelope<E, I> {
         val eventEnvelopes = eventsByStreamId[streamId as Any] as List<EventEnvelope<E, I>>
         return eventEnvelopes[version - 1]
     }

--- a/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/PostgresqlStorage.kt
+++ b/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/PostgresqlStorage.kt
@@ -31,9 +31,11 @@ internal class PostgresqlStorage(
         databaseAdapter.persistEntries(serializedId, expectedVersion, entries, config.tableInfo)
     }
 
-    override fun <E, I> getStreamEvents(streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>> {
+    override fun <E, I> getStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>> {
+        streamType as StringSerializableStreamType<E, I>
+
         val entries = databaseAdapter.getEntriesByStreamIdAndVersion(
-            streamId = streamId.toString(),
+            streamId = streamType.stringIdSerializer.serialize(streamId),
             sinceVersion = sinceVersion,
             tableInfo = config.tableInfo,
         )
@@ -64,9 +66,11 @@ internal class PostgresqlStorage(
         return entries.map { entry -> entry.toEventEnvelope() }
     }
 
-    override fun <E, I> getEventByStreamVersion(streamId: I, version: Int): EventEnvelope<E, I> {
+    override fun <E, I> getEventByStreamVersion(streamType: StreamType<E, I>, streamId: I, version: Int): EventEnvelope<E, I> {
+        streamType as StringSerializableStreamType<E, I>
+
         val entry = databaseAdapter.getEntriesByStreamIdAndVersion(
-            streamId = streamId.toString(),
+            streamId = streamType.stringIdSerializer.serialize(streamId),
             sinceVersion = version - 1,
             limit = 1,
             tableInfo = config.tableInfo,

--- a/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/AppendStreamTest.kt
+++ b/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/AppendStreamTest.kt
@@ -43,7 +43,7 @@ public open class AppendStreamTest<R : Storage, S : EventStore, F : StreamTestFa
         // then
         val eventEnvelope1 = EventEnvelope(CarStreamType, car1StreamId, 1, 1, metadata, event1)
         assertEquals(eventEnvelope1, storage.getEventByPosition(1))
-        assertEquals(eventEnvelope1, storage.getEventByStreamVersion(car1StreamId, 1))
+        assertEquals(eventEnvelope1, storage.getEventByStreamVersion(CarStreamType, car1StreamId, 1))
     }
 
     @Test
@@ -76,9 +76,9 @@ public open class AppendStreamTest<R : Storage, S : EventStore, F : StreamTestFa
         val eventEnvelope1 = EventEnvelope(CarStreamType, car1StreamId, 1, 1, metadata, event1)
         val eventEnvelope2 = EventEnvelope(CarStreamType, car1StreamId, 2, 2, metadata, event2)
         assertEquals(eventEnvelope1, storage.getEventByPosition(1))
-        assertEquals(eventEnvelope1, storage.getEventByStreamVersion(car1StreamId, 1))
+        assertEquals(eventEnvelope1, storage.getEventByStreamVersion(CarStreamType, car1StreamId, 1))
         assertEquals(eventEnvelope2, storage.getEventByPosition(2))
-        assertEquals(eventEnvelope2, storage.getEventByStreamVersion(car1StreamId, 2))
+        assertEquals(eventEnvelope2, storage.getEventByStreamVersion(CarStreamType, car1StreamId, 2))
     }
 
     @Test
@@ -105,7 +105,7 @@ public open class AppendStreamTest<R : Storage, S : EventStore, F : StreamTestFa
         // then
         val eventEnvelope1 = EventEnvelope(CarStreamType, car1StreamId, 2, 3, emptyMap(), event1)
         assertEquals(eventEnvelope1, storage.getEventByPosition(3))
-        assertEquals(eventEnvelope1, storage.getEventByStreamVersion(car1StreamId, 2))
+        assertEquals(eventEnvelope1, storage.getEventByStreamVersion(CarStreamType, car1StreamId, 2))
     }
 
     @Test


### PR DESCRIPTION
Some stores are hard-coding the serialization with a `toString()` method, which causes the wrong id value to be used.