### PR TITLE
feat(es): rework serializer config not to rely on inheritance

### DIFF
--- a/event-store/api/src/commonMain/kotlin/dev/eskt/store/api/BinarySerializableStreamType.kt
+++ b/event-store/api/src/commonMain/kotlin/dev/eskt/store/api/BinarySerializableStreamType.kt
@@ -1,6 +1,0 @@
-package dev.eskt.store.api
-
-public interface BinarySerializableStreamType<E, I> : StreamType<E, I> {
-    public val stringIdSerializer: Serializer<I, String>
-    public val binaryEventSerializer: Serializer<E, ByteArray>
-}

--- a/event-store/api/src/commonMain/kotlin/dev/eskt/store/api/StringSerializableStreamType.kt
+++ b/event-store/api/src/commonMain/kotlin/dev/eskt/store/api/StringSerializableStreamType.kt
@@ -1,6 +1,0 @@
-package dev.eskt.store.api
-
-public interface StringSerializableStreamType<E, I> : StreamType<E, I> {
-    public val stringIdSerializer: Serializer<I, String>
-    public val stringEventSerializer: Serializer<E, String>
-}

--- a/event-store/impl-fs/src/commonMain/kotlin/dev/eskt/store/impl/fs/config.kt
+++ b/event-store/impl-fs/src/commonMain/kotlin/dev/eskt/store/impl/fs/config.kt
@@ -1,36 +1,93 @@
 package dev.eskt.store.impl.fs
 
-import dev.eskt.store.api.BinarySerializableStreamType
 import dev.eskt.store.api.EventMetadata
 import dev.eskt.store.api.Serializer
 import dev.eskt.store.api.StreamType
 import dev.eskt.store.impl.common.binary.serialization.DefaultEventMetadataSerializer
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.serialization.serializer
 import okio.Path
 import okio.Path.Companion.toPath
+import kotlin.reflect.KClass
 
 internal class FileSystemConfig(
     val basePath: Path,
-    val eventMetadataSerializer: Serializer<EventMetadata, ByteArray>,
     val registeredTypes: List<StreamType<*, *>>,
+    internal val payloadSerializers: Map<StreamType<*, *>, Serializer<*, ByteArray>>,
+    internal val idSerializers: Map<StreamType<*, *>, Serializer<*, String>>,
+    internal val eventMetadataSerializer: Serializer<EventMetadata, ByteArray>,
 )
 
 public class FileSystemConfigBuilder(
     private val basePath: String,
 ) {
     private val registeredTypes = mutableListOf<StreamType<*, *>>()
+    private val payloadSerializers = mutableMapOf<StreamType<*, *>, Serializer<*, ByteArray>>()
+    private val idSerializers = mutableMapOf<StreamType<*, *>, Serializer<*, String>>()
     private var eventMetadataSerializer: Serializer<EventMetadata, ByteArray> = DefaultEventMetadataSerializer
 
-    public fun <E, I, T> registerStreamType(streamType: T) where T : StreamType<E, I>, T : BinarySerializableStreamType<E, I> {
-        registeredTypes += streamType as BinarySerializableStreamType<*, *>
+    public fun <E, I, T> registerStreamTypeWith(streamType: T, payloadSerializer: Serializer<E, ByteArray>, idSerializer: Serializer<I, String>)
+    where T : StreamType<E, I> {
+        registeredTypes += streamType as StreamType<*, *>
+        payloadSerializers[streamType] = payloadSerializer as Serializer<*, ByteArray>
+        idSerializers[streamType] = idSerializer as Serializer<*, String>
+    }
+
+    public inline fun <reified E : Any, reified I : Any, T> registerStreamType(
+        streamType: T,
+        payloadSerializer: Serializer<E, ByteArray> = createDefaultPayloadSerializer(E::class),
+        idSerializer: Serializer<I, String> = createDefaultIdSerializer(I::class),
+    )
+    where T : StreamType<E, I> {
+        registerStreamTypeWith(streamType, payloadSerializer, idSerializer)
     }
 
     public fun eventMetadataSerializer(eventMetadataSerializer: Serializer<EventMetadata, ByteArray>) {
         this.eventMetadataSerializer = eventMetadataSerializer
     }
 
+    @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+    public fun <E : Any> createDefaultPayloadSerializer(type: KClass<E>): Serializer<E, ByteArray> {
+        return object : Serializer<E, ByteArray> {
+            val proto = ProtoBuf.Default
+            val serializer = try {
+                type.serializer()
+            } catch (e: kotlinx.serialization.SerializationException) {
+                throw IllegalStateException("$type is not marked with @Serializable, please register this type with an explicit serializer", e)
+            }
+
+            override fun serialize(obj: E): ByteArray {
+                return proto.encodeToByteArray(serializer, obj)
+            }
+
+            override fun deserialize(payload: ByteArray): E {
+                return proto.decodeFromByteArray(serializer, payload)
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    public fun <I : Any> createDefaultIdSerializer(type: KClass<I>): Serializer<I, String> {
+        return object : Serializer<I, String> {
+            override fun serialize(obj: I): String = when (type) {
+                String::class -> obj as String
+                else -> throw IllegalStateException("$type cannot be serialized automatically, please register this type with an explicit id serializer")
+            }
+
+            override fun deserialize(payload: String): I = when (type) {
+                String::class -> payload as I
+                else -> throw IllegalStateException("$type cannot be deserialized automatically, please register this type with an explicit id serializer")
+            }
+        }
+    }
+
     internal fun build(): FileSystemConfig = FileSystemConfig(
         basePath = basePath.toPath(true),
-        eventMetadataSerializer = eventMetadataSerializer,
         registeredTypes = registeredTypes,
+        payloadSerializers = payloadSerializers,
+        idSerializers = idSerializers,
+        eventMetadataSerializer = eventMetadataSerializer,
     )
 }

--- a/event-store/impl-fs/src/commonTest/kotlin/dev/eskt/store/impl/fs/FileSystemStreamTestFactory.kt
+++ b/event-store/impl-fs/src/commonTest/kotlin/dev/eskt/store/impl/fs/FileSystemStreamTestFactory.kt
@@ -13,6 +13,14 @@ internal class FileSystemStreamTestFactory : StreamTestFactory<FileSystemStorage
             CarStreamType,
             DriverStreamType,
         ),
+        payloadSerializers = mapOf(
+            CarStreamType to CarStreamType.binaryEventSerializer,
+            DriverStreamType to DriverStreamType.binaryEventSerializer,
+        ),
+        idSerializers = mapOf(
+            CarStreamType to CarStreamType.stringIdSerializer,
+            DriverStreamType to DriverStreamType.stringIdSerializer,
+        ),
     )
 
     override fun createStorage(): FileSystemStorage {

--- a/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/common/string/serialization/DefaultEventMetadataSerializer.kt
+++ b/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/common/string/serialization/DefaultEventMetadataSerializer.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
-// TODO move this to a `impl-common-string` module when there is another binary implementation
+// TODO move this to a `impl-common-string` module when there is another string implementation
 
 /**
  * Default string serializer for [EventMetadata].

--- a/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/PostgresqlStreamTestFactory.kt
+++ b/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/PostgresqlStreamTestFactory.kt
@@ -15,6 +15,14 @@ internal class PostgresqlStreamTestFactory : StreamTestFactory<PostgresqlStorage
                 CarStreamType,
                 DriverStreamType,
             ),
+            payloadSerializers = mapOf(
+                CarStreamType to CarStreamType.stringEventSerializer,
+                DriverStreamType to DriverStreamType.stringEventSerializer,
+            ),
+            idSerializers = mapOf(
+                CarStreamType to CarStreamType.stringIdSerializer,
+                DriverStreamType to DriverStreamType.stringIdSerializer,
+            ),
             eventMetadataSerializer = DefaultEventMetadataSerializer,
             dataSource = connectionConfig.dataSource(closeables),
             eventTable = "event",

--- a/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/setup.kt
+++ b/event-store/impl-postgresql/src/commonTest/kotlin/dev/eskt/store/impl/pg/setup.kt
@@ -3,6 +3,6 @@ package dev.eskt.store.impl.pg
 @OptIn(ExperimentalStdlibApi::class)
 internal expect fun ConnectionConfig.dataSource(closeables: MutableList<AutoCloseable>): DataSource
 
-internal expect fun ConnectionConfig.create(eventTable: String)
+internal expect fun ConnectionConfig.create(eventTable: String, streamIdType: String = "uuid")
 
 internal expect fun ConnectionConfig.drop()

--- a/event-store/impl-postgresql/src/jvmTest/kotlin/dev/eskt/store/impl/pg/PostgresqlEventStorePublicConstructorTest.kt
+++ b/event-store/impl-postgresql/src/jvmTest/kotlin/dev/eskt/store/impl/pg/PostgresqlEventStorePublicConstructorTest.kt
@@ -1,17 +1,53 @@
 package dev.eskt.store.impl.pg
 
-import com.zaxxer.hikari.HikariDataSource
+import dev.eskt.store.test.w.car.CarProducedEvent
 import dev.eskt.store.test.w.car.CarStreamType
+import dev.eskt.store.test.w.driver.DriverRegisteredEvent
+import dev.eskt.store.test.w.driver.DriverStreamType
+import dev.eskt.store.test.w.part.PartProducedEvent
+import dev.eskt.store.test.w.part.PartStreamType
 import org.junit.Test
+import java.util.UUID
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 
 internal class PostgresqlEventStorePublicConstructorTest {
+    private val connectionConfig = generateTestConnectionConfig()
+    private val closeables = mutableListOf<AutoCloseable>()
+
+    @BeforeTest
+    fun beforeEach() {
+        connectionConfig.create("event", streamIdType = "text")
+    }
+
+    @AfterTest
+    fun afterEach() {
+        closeables.forEach { it.close() }
+        connectionConfig.drop()
+    }
+
     @Test
     fun `public constructor creates event store and allow withStreamType to be called`() {
-        val dataSource = HikariDataSource(generateTestConnectionConfig().copy(database = "postgres").toHikariConfig())
-        val eventStore = PostgresqlEventStore(dataSource, "new_events") {
-            registerStreamType(CarStreamType)
+        val dataSource = connectionConfig.dataSource(closeables)
+        val eventStore = PostgresqlEventStore(dataSource, "event") {
+            registerStreamType(PartStreamType)
+            registerStreamType(DriverStreamType)
+            registerStreamType(CarStreamType, idSerializer = CarStreamType.stringIdSerializer)
         }
 
-        eventStore.withStreamType(CarStreamType)
+        val newPartId = "pr-43234"
+        val partStreamType = eventStore.withStreamType(PartStreamType)
+        partStreamType.appendStream(newPartId, 0, listOf(PartProducedEvent(1, "PR43234")))
+        partStreamType.loadStream(newPartId)
+
+        val newDriverId = UUID.randomUUID()
+        val driverStreamType = eventStore.withStreamType(DriverStreamType)
+        driverStreamType.appendStream(newDriverId, 0, listOf(DriverRegisteredEvent(licence = "9753510", name = "Johnny")))
+        driverStreamType.loadStream(newDriverId)
+
+        val newCarId = UUID.randomUUID()
+        val carStreamType = eventStore.withStreamType(CarStreamType)
+        carStreamType.appendStream(newCarId, 0, listOf(CarProducedEvent(vin = "1233", producer = 1, make = "a", model = "b")))
+        carStreamType.loadStream(newCarId)
     }
 }

--- a/event-store/impl-postgresql/src/jvmTest/kotlin/dev/eskt/store/impl/pg/setup.jvm.kt
+++ b/event-store/impl-postgresql/src/jvmTest/kotlin/dev/eskt/store/impl/pg/setup.jvm.kt
@@ -6,7 +6,7 @@ internal actual fun ConnectionConfig.dataSource(closeables: MutableList<AutoClos
     return HikariDataSource(toHikariConfig()).also { closeables.add(it) }
 }
 
-internal actual fun ConnectionConfig.create(eventTable: String) {
+internal actual fun ConnectionConfig.create(eventTable: String, streamIdType: String) {
     val adminConnectionConfig = copy(database = "postgres", minPoolSize = 1, maxPoolSize = 1)
     val adminHikariConfig = adminConnectionConfig.toHikariConfig()
     val adminDataSource = HikariDataSource(adminHikariConfig)
@@ -32,7 +32,7 @@ internal actual fun ConnectionConfig.create(eventTable: String) {
                 (
                     position    bigserial NOT NULL unique,
                     stream_type text      NOT NULL,
-                    stream_id   uuid      NOT NULL,
+                    stream_id   $streamIdType      NOT NULL,
                     version     int       NOT NULL,
                     payload     jsonb     NOT NULL,
                     metadata    jsonb     NOT NULL,

--- a/event-store/test-harness-model/src/commonMain/kotlin/dev/eskt/store/test/w/car/CarStreamType.kt
+++ b/event-store/test-harness-model/src/commonMain/kotlin/dev/eskt/store/test/w/car/CarStreamType.kt
@@ -2,24 +2,19 @@ package dev.eskt.store.test.w.car
 
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuidFrom
-import dev.eskt.store.api.BinarySerializableStreamType
 import dev.eskt.store.api.Serializer
 import dev.eskt.store.api.StreamType
-import dev.eskt.store.api.StringSerializableStreamType
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.json.Json
 
 @OptIn(ExperimentalSerializationApi::class)
-public data object CarStreamType :
-    StreamType<CarEvent, Uuid>,
-    BinarySerializableStreamType<CarEvent, Uuid>,
-    StringSerializableStreamType<CarEvent, Uuid> {
+public data object CarStreamType : StreamType<CarEvent, Uuid> {
     private val eventSerializer = CarEvent.serializer()
 
     override val id: String = "Car"
 
-    override val stringIdSerializer: Serializer<Uuid, String> = object : Serializer<Uuid, String> {
+    val stringIdSerializer: Serializer<Uuid, String> = object : Serializer<Uuid, String> {
         override fun serialize(obj: Uuid): String {
             return obj.toString()
         }
@@ -29,7 +24,7 @@ public data object CarStreamType :
         }
     }
 
-    override val stringEventSerializer: Serializer<CarEvent, String> = object : Serializer<CarEvent, String> {
+    val stringEventSerializer: Serializer<CarEvent, String> = object : Serializer<CarEvent, String> {
         private val json = Json {
             ignoreUnknownKeys = true
         }
@@ -43,7 +38,7 @@ public data object CarStreamType :
         }
     }
 
-    override val binaryEventSerializer: Serializer<CarEvent, ByteArray> = object : Serializer<CarEvent, ByteArray> {
+    val binaryEventSerializer: Serializer<CarEvent, ByteArray> = object : Serializer<CarEvent, ByteArray> {
         private val cbor = Cbor {
             ignoreUnknownKeys = true
         }

--- a/event-store/test-harness-model/src/commonMain/kotlin/dev/eskt/store/test/w/driver/DriverStreamType.kt
+++ b/event-store/test-harness-model/src/commonMain/kotlin/dev/eskt/store/test/w/driver/DriverStreamType.kt
@@ -2,24 +2,19 @@ package dev.eskt.store.test.w.driver
 
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuidFrom
-import dev.eskt.store.api.BinarySerializableStreamType
 import dev.eskt.store.api.Serializer
 import dev.eskt.store.api.StreamType
-import dev.eskt.store.api.StringSerializableStreamType
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.json.Json
 
 @OptIn(ExperimentalSerializationApi::class)
-public data object DriverStreamType :
-    StreamType<DriverEvent, Uuid>,
-    BinarySerializableStreamType<DriverEvent, Uuid>,
-    StringSerializableStreamType<DriverEvent, Uuid> {
+public data object DriverStreamType : StreamType<DriverEvent, Uuid> {
     private val eventSerializer = DriverEvent.serializer()
 
     override val id: String = "Driver"
 
-    override val stringIdSerializer: Serializer<Uuid, String> = object : Serializer<Uuid, String> {
+    val stringIdSerializer: Serializer<Uuid, String> = object : Serializer<Uuid, String> {
         override fun serialize(obj: Uuid): String {
             return obj.toString()
         }
@@ -29,7 +24,7 @@ public data object DriverStreamType :
         }
     }
 
-    override val stringEventSerializer: Serializer<DriverEvent, String> = object : Serializer<DriverEvent, String> {
+    val stringEventSerializer: Serializer<DriverEvent, String> = object : Serializer<DriverEvent, String> {
         private val json = Json {
             ignoreUnknownKeys = true
         }
@@ -43,7 +38,7 @@ public data object DriverStreamType :
         }
     }
 
-    override val binaryEventSerializer: Serializer<DriverEvent, ByteArray> = object : Serializer<DriverEvent, ByteArray> {
+    val binaryEventSerializer: Serializer<DriverEvent, ByteArray> = object : Serializer<DriverEvent, ByteArray> {
         private val cbor = Cbor {
             ignoreUnknownKeys = true
         }

--- a/event-store/test-harness-model/src/commonMain/kotlin/dev/eskt/store/test/w/part/PartStreamType.kt
+++ b/event-store/test-harness-model/src/commonMain/kotlin/dev/eskt/store/test/w/part/PartStreamType.kt
@@ -1,0 +1,7 @@
+package dev.eskt.store.test.w.part
+
+import dev.eskt.store.api.StreamType
+
+public object PartStreamType : StreamType<PartEvent, String> {
+    override val id: String = "Part"
+}

--- a/event-store/test-harness-model/src/commonMain/kotlin/dev/eskt/store/test/w/part/events.kt
+++ b/event-store/test-harness-model/src/commonMain/kotlin/dev/eskt/store/test/w/part/events.kt
@@ -1,0 +1,12 @@
+package dev.eskt.store.test.w.part
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+public sealed interface PartEvent
+
+@Serializable
+public data class PartProducedEvent(
+    val producer: Long,
+    val partNumber: String,
+) : PartEvent


### PR DESCRIPTION
The serialization config for stream types currently has 2 issues:
* It relies on sub-interfaces of `StreamType` to be implemented so serializers can be configured.
* It is mostly boilerplate since most implementations just delegate the serialization to kotlinx-serialization.

This PR aims to address those 2 points by moving the configuration of serializers to the `registerStreamType()` method, which now takes 2 extra parameters, one for configuring the payload serializer and another one to configure the id serializer.
Also, to address the second point, those 2 new parameters are optional and default serializer implementation providers that delegates the serialization to kotlinx-serialization are provided.

This is a breaking change if someone is using different serializers than the default, or if any types other than `String` or `java.util.UUID` are being used. Public usage of this library at the moment is practically to zero, so we are going ahead with this change.