### PR TITLE
feat(es): add useStream to allow low-memory event consumption

### DIFF
--- a/event-store/api/src/commonMain/kotlin/dev/eskt/store/api/StreamTypeHandler.kt
+++ b/event-store/api/src/commonMain/kotlin/dev/eskt/store/api/StreamTypeHandler.kt
@@ -12,6 +12,17 @@ public interface StreamTypeHandler<E, I> {
     ): List<EventEnvelope<E, I>>
 
     /**
+     * Allow events from the stream to be consumed through a [Sequence] in a safe way.
+     * Events from the stream will be loaded progressively as the sequence is iterated on,
+     * and all underlying resources will be closed by the end of this call.
+     */
+    public fun <R> useStream(
+        streamId: I,
+        sinceVersion: Int = 0,
+        consume: (Sequence<EventEnvelope<E, I>>) -> R,
+    ): R
+
+    /**
      * Append new events into an event stream.
      *
      * @return the version of the aggregate after those events are appended, or;

--- a/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/impl/common/base/StreamTypeHandler.kt
+++ b/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/impl/common/base/StreamTypeHandler.kt
@@ -16,6 +16,10 @@ public class StreamTypeHandler<E, I>(
         return storage.getStreamEvents(streamType, streamId, sinceVersion)
     }
 
+    override fun <R> useStream(streamId: I, sinceVersion: Int, consume: (Sequence<EventEnvelope<E, I>>) -> R): R {
+        return storage.useStreamEvents(streamType, streamId, sinceVersion, consume)
+    }
+
     override fun appendStream(streamId: I, expectedVersion: Int, events: List<E>, metadata: EventMetadata): Int {
         try {
             storage.add(streamType, streamId, expectedVersion, events, metadata)

--- a/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/storage/api/Storage.kt
+++ b/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/storage/api/Storage.kt
@@ -10,6 +10,8 @@ public interface Storage {
 
     public fun <E, I> getStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>>
 
+    public fun <E, I, R> useStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int, consume: (Sequence<EventEnvelope<E, I>>) -> R): R
+
     public fun <E, I> getEventByPosition(position: Long): EventEnvelope<E, I>
 
     public fun loadEventBatch(sincePosition: Long, batchSize: Int): List<EventEnvelope<Any, Any>>

--- a/event-store/impl-fs/src/commonMain/kotlin/dev/eskt/store/impl/fs/FileSystemStorage.kt
+++ b/event-store/impl-fs/src/commonMain/kotlin/dev/eskt/store/impl/fs/FileSystemStorage.kt
@@ -137,6 +137,17 @@ public class FileSystemStorage internal constructor(
         }
     }
 
+    public override fun <E, I, R> useStreamEvents(
+        streamType: StreamType<E, I>,
+        streamId: I,
+        sinceVersion: Int,
+        consume: (Sequence<EventEnvelope<E, I>>) -> R,
+    ): R {
+        // TODO optimize this implementation, we don't need to load the entire list
+        val events = getStreamEvents(streamType, streamId, sinceVersion)
+        return consume.invoke(events.asSequence())
+    }
+
     override fun <E, I> getEventByPosition(position: Long): EventEnvelope<E, I> {
         if (!fs.exists(posPath)) {
             throw IllegalStateException("Event store is empty, file $posPath does not exist")

--- a/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/DatabaseAdapter.kt
+++ b/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/DatabaseAdapter.kt
@@ -28,6 +28,14 @@ internal expect class DatabaseAdapter(dataSource: DataSource) {
         tableInfo: TableInfo,
     ): List<DatabaseEntry>
 
+    fun <R> useEntriesByStreamIdAndVersion(
+        streamId: String,
+        sinceVersion: Int,
+        limit: Int = Int.MAX_VALUE,
+        tableInfo: TableInfo,
+        consume: (Sequence<DatabaseEntry>) -> R,
+    ): R
+
     fun persistEntries(
         streamId: String,
         expectedVersion: Int,

--- a/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/LoadStreamTest.kt
+++ b/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/LoadStreamTest.kt
@@ -34,6 +34,24 @@ public open class LoadStreamTest<R : Storage, S : EventStore, F : StreamTestFact
 
     @Test
     @JsName("test2")
+    public fun `given no events - when using events of a stream - list is empty`() {
+        // given
+        val storage = factory.newStorage()
+
+        // when
+        val eventStore = factory.newEventStore(storage)
+        val eventStream = eventStore.withStreamType(CarStreamType)
+
+        val listFromUse = eventStream.useStream(streamId = car1StreamId) { stream ->
+            stream.toList()
+        }
+
+        // then
+        assertEquals(eventStream.loadStream(streamId = car1StreamId), listFromUse)
+    }
+
+    @Test
+    @JsName("test3")
     public fun `given 3 event from different streams - when loading one stream - correct events are loaded`() {
         // given
         val storage = factory.newStorage()
@@ -64,6 +82,43 @@ public open class LoadStreamTest<R : Storage, S : EventStore, F : StreamTestFact
                     event = CarSoldEvent(seller = 1, buyer = 2, 2500.00f),
                 ),
                 actual = eventEnvelopes.last(),
+            )
+        }
+    }
+
+    @Test
+    @JsName("test4")
+    public fun `given 3 event from different streams - when using one stream - correct events are loaded`() {
+        // given
+        val storage = factory.newStorage()
+        storage.add(CarStreamType, car1StreamId, 1, CarProducedEvent(vin = "123", producer = 1, make = "kia", model = "rio"))
+        storage.add(CarStreamType, car2StreamId, 1, CarProducedEvent(vin = "456", producer = 1, make = "kia", model = "rio"))
+        storage.add(CarStreamType, car1StreamId, 2, CarSoldEvent(seller = 1, buyer = 2, 2500.00f))
+
+        // when
+        val eventStore = factory.newEventStore(storage)
+
+        (0..1).forEach { sinceVersion ->
+            val eventStream = eventStore.withStreamType(CarStreamType)
+            val events = eventStream.useStream(
+                streamId = car1StreamId,
+                sinceVersion = sinceVersion,
+            ) { stream ->
+                stream.toList()
+            }
+
+            // then
+            assertEquals(eventStream.loadStream(streamId = car1StreamId, sinceVersion = sinceVersion), events)
+            assertEquals(
+                expected = EventEnvelope(
+                    streamType = CarStreamType,
+                    streamId = car1StreamId,
+                    version = 2,
+                    position = 3,
+                    metadata = emptyMap(),
+                    event = CarSoldEvent(seller = 1, buyer = 2, 2500.00f),
+                ),
+                actual = events.last(),
             )
         }
     }


### PR DESCRIPTION
Provide a way to consume events from a stream without loading all of them in memory. This designed is based on other closeable-related APIs such as https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.io/use-lines.html