### PR TITLE
refactor(es): remove getEntriesByStreamIdAndVersion from DatabaseAdapter

### DIFF
--- a/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/DatabaseAdapter.kt
+++ b/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/DatabaseAdapter.kt
@@ -21,13 +21,6 @@ internal expect class DatabaseAdapter(dataSource: DataSource) {
         tableInfo: TableInfo,
     ): List<DatabaseEntry>
 
-    fun getEntriesByStreamIdAndVersion(
-        streamId: String,
-        sinceVersion: Int,
-        limit: Int = Int.MAX_VALUE,
-        tableInfo: TableInfo,
-    ): List<DatabaseEntry>
-
     fun <R> useEntriesByStreamIdAndVersion(
         streamId: String,
         sinceVersion: Int,

--- a/event-store/impl-postgresql/src/jvmMain/kotlin/dev/eskt/store/impl/pg/DatabaseAdapter.jvm.kt
+++ b/event-store/impl-postgresql/src/jvmMain/kotlin/dev/eskt/store/impl/pg/DatabaseAdapter.jvm.kt
@@ -69,15 +69,6 @@ internal actual class DatabaseAdapter actual constructor(
         }
     }
 
-    actual fun getEntriesByStreamIdAndVersion(
-        streamId: String,
-        sinceVersion: Int,
-        limit: Int,
-        tableInfo: TableInfo,
-    ): List<PostgresqlStorage.DatabaseEntry> {
-        return useEntriesByStreamIdAndVersion(streamId, sinceVersion, limit, tableInfo) { it.toList() }
-    }
-
     actual fun <R> useEntriesByStreamIdAndVersion(
         streamId: String,
         sinceVersion: Int,


### PR DESCRIPTION
Remove some redundant methods after the last PR introducing `useStream`.