### PR TITLE
refactor(store): implement loadStream with useStream

### DIFF
--- a/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/impl/common/base/StreamTypeHandler.kt
+++ b/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/impl/common/base/StreamTypeHandler.kt
@@ -13,7 +13,9 @@ public class StreamTypeHandler<E, I>(
     private val storage: Storage,
 ) : StreamTypeHandler<E, I> {
     override fun loadStream(streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>> {
-        return storage.getStreamEvents(streamType, streamId, sinceVersion)
+        return storage.useStreamEvents(streamType, streamId, sinceVersion) { stream ->
+            stream.toList()
+        }
     }
 
     override fun <R> useStream(streamId: I, sinceVersion: Int, consume: (Sequence<EventEnvelope<E, I>>) -> R): R {

--- a/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/storage/api/Storage.kt
+++ b/event-store/impl-common/src/commonMain/kotlin/dev/eskt/store/storage/api/Storage.kt
@@ -8,8 +8,6 @@ public interface Storage {
     @Throws(StorageVersionMismatchException::class)
     public fun <E, I> add(streamType: StreamType<E, I>, streamId: I, expectedVersion: Int, events: List<E>, metadata: EventMetadata)
 
-    public fun <E, I> getStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>>
-
     public fun <E, I, R> useStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int, consume: (Sequence<EventEnvelope<E, I>>) -> R): R
 
     public fun loadEventBatch(sincePosition: Long, batchSize: Int): List<EventEnvelope<Any, Any>>

--- a/event-store/impl-memory/src/commonMain/kotlin/dev/eskt/store/impl/memory/CopyOnWriteInMemoryStorage.kt
+++ b/event-store/impl-memory/src/commonMain/kotlin/dev/eskt/store/impl/memory/CopyOnWriteInMemoryStorage.kt
@@ -19,10 +19,6 @@ internal class CopyOnWriteInMemoryStorage(
 
     private val writeLock = reentrantLock()
 
-    override fun <E, I> getStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>> {
-        return streamEvents<E, I>(streamId).drop(sinceVersion)
-    }
-
     override fun <E, I, R> useStreamEvents(
         streamType: StreamType<E, I>,
         streamId: I,

--- a/event-store/impl-memory/src/commonMain/kotlin/dev/eskt/store/impl/memory/SynchronizedInMemoryStorage.kt
+++ b/event-store/impl-memory/src/commonMain/kotlin/dev/eskt/store/impl/memory/SynchronizedInMemoryStorage.kt
@@ -28,16 +28,6 @@ internal class SynchronizedInMemoryStorage(
         }
     }
 
-    override fun <E, I> getStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>> {
-        return streamEvents<E, I>(streamId).asSequence()
-            .drop(sinceVersion)
-            .let { sequence ->
-                withReadLock {
-                    sequence.toList()
-                }
-            }
-    }
-
     override fun <E, I, R> useStreamEvents(
         streamType: StreamType<E, I>,
         streamId: I,

--- a/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/PostgresqlStorage.kt
+++ b/event-store/impl-postgresql/src/commonMain/kotlin/dev/eskt/store/impl/pg/PostgresqlStorage.kt
@@ -30,17 +30,6 @@ internal class PostgresqlStorage(
         databaseAdapter.persistEntries(serializedId, expectedVersion, entries, config.tableInfo)
     }
 
-    override fun <E, I> getStreamEvents(streamType: StreamType<E, I>, streamId: I, sinceVersion: Int): List<EventEnvelope<E, I>> {
-        if (streamType.id !in registeredTypes) throw IllegalStateException("Unregistered type: $streamType")
-        return databaseAdapter.useEntriesByStreamIdAndVersion(
-            streamId = streamType.stringIdSerializer.serialize(streamId),
-            sinceVersion = sinceVersion,
-            tableInfo = config.tableInfo,
-        ) { entries ->
-            entries.map { entry -> entry.toEventEnvelope<E, I>() }.toList()
-        }
-    }
-
     override fun <E, I, R> useStreamEvents(
         streamType: StreamType<E, I>,
         streamId: I,

--- a/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/_helper.kt
+++ b/event-store/test-harness/src/commonMain/kotlin/dev/eskt/store/test/_helper.kt
@@ -15,5 +15,7 @@ internal fun <E, I> Storage.getEventByPosition(position: Long): EventEnvelope<E,
 }
 
 internal fun <E, I> Storage.getEventByStreamVersion(streamType: StreamType<E, I>, streamId: I, version: Int): EventEnvelope<E, I> {
-    return getStreamEvents(streamType, streamId, version - 1).first()
+    return useStreamEvents(streamType, streamId, version - 1) { stream ->
+        stream.first()
+    }
 }


### PR DESCRIPTION
This simplifies the `Storage` contract by implementing the `loadStream` using the sequence provided by `useStream`.